### PR TITLE
Avoid interfering with Bilibili header by using floating control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Bili-Video-Link-Copy
-Adds a floating button with a quality dropdown that copies a direct MP4 link of the current Bilibili video to the clipboard.
+Adds an MP4 copy button with a quality dropdown into Bilibili's video toolbar, copying the direct MP4 link of the current video to the clipboard.
 
 TamperMonkey browser extension: https://www.tampermonkey.net/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Bili-Video-Link-Copy
-Adds an MP4 copy button with a quality dropdown into Bilibili's video toolbar, copying the direct MP4 link of the current video to the clipboard.
+Adds an MP4 copy button with a quality dropdown to the right side of Bilibili's video title area (`#viewbox_report`), copying the direct MP4 link of the current video to the clipboard.
 
 TamperMonkey browser extension: https://www.tampermonkey.net/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Bili-Video-Link-Copy
-Add a button under Bilibili Video to copy a direct link to mp4 video source to clipboard.
+Adds a floating button with a quality dropdown that copies a direct MP4 link of the current Bilibili video to the clipboard.
 
 TamperMonkey browser extension: https://www.tampermonkey.net/
 

--- a/bilibili-video-link-copy.user.js
+++ b/bilibili-video-link-copy.user.js
@@ -3,8 +3,8 @@
 // @name:zh-CN           Bilibili 视频直链复制器
 // @namespace            https://github.com/TZFC
 // @version              1.0
-// @description          Button + dropdown inside #arc_toolbar_report .video-toolbar-right; dark-mode readable; fetches all progressive MP4 qualities.
-// @description:zh-CN    在哔哩哔哩视频工具栏中添加带清晰度选择的复制 MP4 按钮，支持深色模式。
+// @description          Floating button + dropdown that copies direct MP4 links; dark-mode readable; fetches all progressive MP4 qualities.
+// @description:zh-CN    浮动的带清晰度选择的复制 MP4 按钮，支持深色模式。
 // @match                *://www.bilibili.com/video/*
 // @icon                 https://www.bilibili.com/favicon.ico
 // @license              GPL-3.0
@@ -36,21 +36,21 @@
 
   const style = document.createElement("style");
   style.textContent = `
-    #arc_toolbar_report .video-toolbar-right [data-bili-mp4] { display:inline-flex; align-items:center; gap:8px; margin-left:8px; color-scheme: light dark; }
-    #arc_toolbar_report .video-toolbar-right .bili_mp4_select {
+    [data-bili-mp4] { position:fixed; top:80px; right:20px; display:flex; align-items:center; gap:8px; color-scheme: light dark; z-index:99999; }
+    [data-bili-mp4] .bili_mp4_select {
       font-size:12px; min-width:200px; padding:4px 8px; appearance:auto; -webkit-appearance:auto; -moz-appearance:auto;
     }
-    #arc_toolbar_report .video-toolbar-right .bili_mp4_select option:disabled { opacity:0.7; }
+    [data-bili-mp4] .bili_mp4_select option:disabled { opacity:0.7; }
     @media (prefers-color-scheme: dark) {
-      #arc_toolbar_report .video-toolbar-right .bili_mp4_select { color:#e8e8e8 !important; background-color:#16181b !important; border:1px solid rgba(255,255,255,0.18) !important; -webkit-text-fill-color:#e8e8e8 !important; }
-      #arc_toolbar_report .video-toolbar-right .bili_mp4_select option { color:#e8e8e8 !important; background-color:#16181b !important; }
-      #arc_toolbar_report .video-toolbar-right .bili_mp4_select option:disabled { color:rgba(232,232,232,0.75) !important; }
+      [data-bili-mp4] .bili_mp4_select { color:#e8e8e8 !important; background-color:#16181b !important; border:1px solid rgba(255,255,255,0.18) !important; -webkit-text-fill-color:#e8e8e8 !important; }
+      [data-bili-mp4] .bili_mp4_select option { color:#e8e8e8 !important; background-color:#16181b !important; }
+      [data-bili-mp4] .bili_mp4_select option:disabled { color:rgba(232,232,232,0.75) !important; }
     }
-    #arc_toolbar_report .video-toolbar-right .bili_mp4_button {
+    [data-bili-mp4] .bili_mp4_button {
       cursor:pointer; padding:6px 12px; font-size:12px; line-height:1; border:none; border-radius:8px;
       background:linear-gradient(135deg,#ff7ac3 0%,#7aa8ff 100%); color:#101010; font-weight:700;
     }
-    #arc_toolbar_report .video-toolbar-right .bili_mp4_button[disabled]{ opacity:.6; cursor:not-allowed; }
+    [data-bili-mp4] .bili_mp4_button[disabled]{ opacity:.6; cursor:not-allowed; }
   `;
   document.head.appendChild(style);
 
@@ -196,43 +196,5 @@
     setTimeout(()=>setBtn(controls.btn, L.button_idle, false), 1200);
   }, { passive:true });
 
-  const getToolbarRight = () => document.querySelector("#arc_toolbar_report .video-toolbar-right");
-  const getArcContainer = () => document.getElementById("arc_toolbar_report");
-
-  let rafQueued = false, mounting = false, mo = null;
-
-  const mount = () => {
-    if (mounting) return;
-    mounting = true;
-    try {
-      const t = getToolbarRight();
-      if (!t) return;
-      if (controls.wrap.parentElement !== t) {
-        t.appendChild(controls.wrap);
-      }
-    } finally {
-      mounting = false;
-    }
-  };
-
-  const scheduleMount = () => {
-    if (rafQueued) return;
-    rafQueued = true;
-    requestAnimationFrame(() => {
-      rafQueued = false;
-      mount();
-    });
-  };
-
-  const ensureObserver = () => {
-    if (mo) return;
-    const arc = getArcContainer();
-    if (!arc) return;
-    mo = new MutationObserver(() => { scheduleMount(); });
-    mo.observe(arc, { childList:true, subtree:true });
-  };
-
-  scheduleMount();
-  ensureObserver();
-  window.addEventListener("popstate", scheduleMount);
+  document.body.appendChild(controls.wrap);
 })();

--- a/bilibili-video-link-copy.user.js
+++ b/bilibili-video-link-copy.user.js
@@ -3,8 +3,8 @@
 // @name:zh-CN           Bilibili 视频直链复制器
 // @namespace            https://github.com/TZFC
 // @version              1.0
-// @description          Floating button + dropdown that copies direct MP4 links; dark-mode readable; fetches all progressive MP4 qualities.
-// @description:zh-CN    浮动的带清晰度选择的复制 MP4 按钮，支持深色模式。
+// @description          Adds MP4 copy button with quality dropdown to video toolbar; dark-mode readable; fetches all progressive MP4 qualities.
+// @description:zh-CN    在工具栏中添加带清晰度选择的 MP4 复制按钮，支持深色模式。
 // @match                *://www.bilibili.com/video/*
 // @icon                 https://www.bilibili.com/favicon.ico
 // @license              GPL-3.0
@@ -36,7 +36,7 @@
 
   const style = document.createElement("style");
   style.textContent = `
-    [data-bili-mp4] { position:fixed; top:80px; right:20px; display:flex; align-items:center; gap:8px; color-scheme: light dark; z-index:99999; }
+    [data-bili-mp4] { display:flex; align-items:center; gap:8px; color-scheme: light dark; }
     [data-bili-mp4] .bili_mp4_select {
       font-size:12px; min-width:200px; padding:4px 8px; appearance:auto; -webkit-appearance:auto; -moz-appearance:auto;
     }
@@ -153,8 +153,9 @@
   };
 
   const createControls = ()=>{
-    const wrap = document.createElement("span");
+    const wrap = document.createElement("div");
     wrap.setAttribute("data-bili-mp4","1");
+    wrap.className = "video-toolbar-right-item";
     const sel = document.createElement("select"); sel.className = "bili_mp4_select"; sel.title = L.dropdown_title;
     const ph = document.createElement("option"); ph.value=""; ph.disabled=true; ph.selected=true; ph.textContent=L.placeholder; sel.appendChild(ph);
     const btn = document.createElement("button"); btn.className="bili_mp4_button"; btn.title=L.button_title; btn.textContent=L.button_idle;
@@ -196,5 +197,14 @@
     setTimeout(()=>setBtn(controls.btn, L.button_idle, false), 1200);
   }, { passive:true });
 
-  document.body.appendChild(controls.wrap);
+  const inject = () => {
+    const bar = document.querySelector(".video-toolbar-right");
+    if (!bar) return false;
+    bar.insertBefore(controls.wrap, bar.firstChild);
+    return true;
+  };
+  if (!inject()) {
+    const mo = new MutationObserver(() => { if (inject()) mo.disconnect(); });
+    mo.observe(document.body, { childList: true, subtree: true });
+  }
 })();

--- a/bilibili-video-link-copy.user.js
+++ b/bilibili-video-link-copy.user.js
@@ -36,7 +36,7 @@
 
   const style = document.createElement("style");
   style.textContent = `
-    [data-bili-mp4] { display:flex; align-items:center; gap:8px; color-scheme: light dark; }
+    [data-bili-mp4] { display:flex; align-items:center; gap:8px; color-scheme: light dark; position:absolute; top:0; right:0; }
     [data-bili-mp4] .bili_mp4_select {
       font-size:12px; min-width:200px; padding:4px 8px; appearance:auto; -webkit-appearance:auto; -moz-appearance:auto;
     }
@@ -155,7 +155,6 @@
   const createControls = ()=>{
     const wrap = document.createElement("div");
     wrap.setAttribute("data-bili-mp4","1");
-    wrap.className = "video-toolbar-right-item";
     const sel = document.createElement("select"); sel.className = "bili_mp4_select"; sel.title = L.dropdown_title;
     const ph = document.createElement("option"); ph.value=""; ph.disabled=true; ph.selected=true; ph.textContent=L.placeholder; sel.appendChild(ph);
     const btn = document.createElement("button"); btn.className="bili_mp4_button"; btn.title=L.button_title; btn.textContent=L.button_idle;
@@ -198,9 +197,11 @@
   }, { passive:true });
 
   const inject = () => {
-    const bar = document.querySelector(".video-toolbar-right");
-    if (!bar) return false;
-    bar.insertBefore(controls.wrap, bar.firstChild);
+    const box = document.getElementById("viewbox_report");
+    if (!box) return false;
+    const cs = window.getComputedStyle(box);
+    if (cs.position === "static") box.style.position = "relative";
+    box.appendChild(controls.wrap);
     return true;
   };
   if (!inject()) {


### PR DESCRIPTION
## Summary
- place MP4 copy controls in a fixed floating container instead of inside the toolbar
- update metadata and README to describe new placement

## Testing
- `node --check Bili-Video-Link-Copy/bilibili-video-link-copy.user.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5098131988325a266ebe295d2a19e